### PR TITLE
v0.1.7: add reset timer count button

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -16,6 +16,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_ACCESS_TOKEN }}
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v1

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -2,7 +2,7 @@ name: Tag release version when PR is merged
 
 on:
   pull_request:
-    types: [closed]
+    types: [closed, opened, reopened]
 
 jobs:
   tag-version:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Release
         uses: softprops/action-gh-release@v2
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_ACCESS_TOKEN }}
         with:
           body_path: CHANGELOG.md
           files: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Changelog for v0.1.7
+- Added a "reset timers" link
+
+### Minor changes
+- Fix an issue in ci/cd that prevents autotriggering the release build
+
+<details>
+<summary>Looking for older changelogs? Click here!</summary>
 ## Changelog for v0.1.6
 - Added a timer ring component
 
@@ -9,8 +17,6 @@
 ### Bug fixes
 - Fixed an issue where the timer count wouldn't reset correctly. This issue was introduced in v0.1.5
 
-<details>
-<summary>Looking for older changelogs? Click here!</summary>
 ## Changelog for v0.1.5
 
 - Added a switch where you can switch to light and dark mode, and auto-syncing with device theme to select the default one.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "StudyMate — ADHD-friendly study timer",
   "description": "StudyMate — Pomodoro timer 🍅, motivational quotes 💬 and a funny parrot 🦜 to help you study more effectively",
   "private": true,
-  "version": "0.1.6",
+  "version": "0.1.7",
   "type": "module",
   "scripts": {
     "dev": "wxt",

--- a/src/entrypoints/background.ts
+++ b/src/entrypoints/background.ts
@@ -92,7 +92,23 @@ export default defineBackground(async () => {
 
   browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
     if (message.type === "GET_STATE") {
-      sendResponse({ timerType, completedSessions });
+      (async () => {
+        const now = new Date();
+        const currentLastUpdated = await sessionsLastUpdated.getValue();
+
+        if (currentLastUpdated !== 0 && !sameLocalDay(currentLastUpdated, now)) {
+          completedSessions = {
+            completedPomodoros: 0,
+            completedShortBreaks: 0,
+            completedLongBreaks: 0,
+          };
+          await completedSessionsStorage.setValue(completedSessions);
+          await sessionsLastUpdated.setValue(now.getTime());
+        }
+
+        sendResponse({ timerType, completedSessions });
+      })();
+      return true;
     } else if (message.type === "START_TIMER") {
       playTimer(message.time);
       sendResponse({ status: "timerStarted", time: message.time });
@@ -105,6 +121,15 @@ export default defineBackground(async () => {
         type: "INIT_TIMER",
         timerType: message.timerType,
       });
+    } else if (message.type === "RESET_SESSIONS") {
+      completedSessions = {
+        completedPomodoros: 0,
+        completedShortBreaks: 0,
+        completedLongBreaks: 0,
+      };
+      completedSessionsStorage.setValue(completedSessions);
+      sessionsLastUpdated.setValue(Date.now());
+      sendResponse({ completedSessions });
     }
 
     return true;

--- a/src/entrypoints/background.ts
+++ b/src/entrypoints/background.ts
@@ -97,7 +97,7 @@ export default defineBackground(async () => {
   };
 
   browser.runtime.onMessage.addListener(
-    async (message, sender, sendResponse) => {
+    (message, sender, sendResponse) => {
       if (message.type === "GET_STATE") {
         (async () => {
           const now = new Date();
@@ -122,27 +122,33 @@ export default defineBackground(async () => {
       } else if (message.type === "START_TIMER") {
         playTimer(message.time);
         sendResponse({ status: "timerStarted", time: message.time });
+        return true;
       } else if (message.type === "PAUSE_TIMER") {
         pauseTimer();
         sendResponse({ status: "timerPaused", time: message.time });
+        return true;
       } else if (message.type === "INIT_TIMER") {
         timerType = message.timerType;
         browser.runtime.sendMessage({
           type: "INIT_TIMER",
           timerType: message.timerType,
         });
+        sendResponse({ status: "inited", timerType });
       } else if (message.type === "RESET_SESSIONS") {
-        completedSessions = {
-          completedPomodoros: 0,
-          completedShortBreaks: 0,
-          completedLongBreaks: 0,
-        };
-        completedSessionsStorage.setValue(completedSessions);
-        sessionsLastUpdated.setValue(Date.now());
-        sendResponse({ completedSessions });
+        (async () => {
+          completedSessions = {
+            completedPomodoros: 0,
+            completedShortBreaks: 0,
+            completedLongBreaks: 0,
+          };
+          await completedSessionsStorage.setValue(completedSessions);
+          await sessionsLastUpdated.setValue(Date.now());
+          sendResponse({ completedSessions });
+        })();
+        return true;
       }
 
-      return true;
+      return false;
     },
   );
 });

--- a/src/entrypoints/popup/App.svelte
+++ b/src/entrypoints/popup/App.svelte
@@ -38,8 +38,8 @@
     <div class="timer-selection">
         <TimerType bind:timerType bind:buttonState bind:completedSessions />
         <div class="reset-container">
-            <a
-                href="#"
+            <button
+                type="button"
                 onclick={async () => {
                     const response = await browser.runtime.sendMessage({
                         type: "RESET_SESSIONS",
@@ -51,7 +51,7 @@
                 }}
             >
                 Reset finished timer count
-            </a>
+            </button>
         </div>
     </div>
     <div class="pomodoro">

--- a/src/entrypoints/popup/App.svelte
+++ b/src/entrypoints/popup/App.svelte
@@ -18,7 +18,10 @@
 
     const ringProgress = $derived(
         timerRing.totalMs > 0
-            ? Math.min(1, Math.max(0, timerRing.remainingMs / timerRing.totalMs))
+            ? Math.min(
+                  1,
+                  Math.max(0, timerRing.remainingMs / timerRing.totalMs),
+              )
             : 1,
     );
 </script>
@@ -32,8 +35,24 @@
         <div class="switch-mode"><SwitchMode /></div>
     </div>
 
-    <div class="timer-type">
+    <div class="timer-selection">
         <TimerType bind:timerType bind:buttonState bind:completedSessions />
+        <div class="reset-container">
+            <a
+                href="#"
+                onclick={async () => {
+                    const response = await browser.runtime.sendMessage({
+                        type: "RESET_SESSIONS",
+                    });
+
+                    if (response && response.completedSessions) {
+                        completedSessions = response.completedSessions;
+                    }
+                }}
+            >
+                Reset finished timer count
+            </a>
+        </div>
     </div>
     <div class="pomodoro">
         <TimerRing progress={ringProgress}>

--- a/src/entrypoints/popup/app.css
+++ b/src/entrypoints/popup/app.css
@@ -56,7 +56,7 @@ body {
 }
 
 h1 {
-    font-family: "Manrope", sans-serif;
+    font-family: Manrope, sans-serif;
     font-size: 3.2em;
     line-height: 1.1;
 }
@@ -74,16 +74,22 @@ h1 {
     margin-top: -18px;
 }
 
-.reset-container a {
+.reset-container button {
     font-size: 0.75rem;
-    font-family: "Manrope", sans-serif;
+    font-family: Manrope, sans-serif;
     font-weight: 500;
     font-style: italic;
     opacity: 0.7;
     transition: opacity 0.2s;
+    background: none;
+    border: none;
+    padding: 0;
+    color: inherit;
+    text-decoration: inherit;
+    cursor: pointer;
 }
 
-.reset-container a:hover {
+.reset-container button:hover {
     opacity: 1;
 }
 

--- a/src/entrypoints/popup/app.css
+++ b/src/entrypoints/popup/app.css
@@ -61,8 +61,30 @@ h1 {
     line-height: 1.1;
 }
 
-.timer-type {
+.timer-selection {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
     margin-top: 2rem;
+}
+
+.reset-container {
+    width: 306px;
+    text-align: left;
+    margin-top: -18px;
+}
+
+.reset-container a {
+    font-size: 0.75rem;
+    font-family: "Manrope", sans-serif;
+    font-weight: 500;
+    font-style: italic;
+    opacity: 0.7;
+    transition: opacity 0.2s;
+}
+
+.reset-container a:hover {
+    opacity: 1;
 }
 
 .pomodoro {


### PR DESCRIPTION
## Changelog for v0.1.7
- Added a "reset timers" link

### Minor changes
- Fix an issue in ci/cd that prevents autotriggering the release build

<details>
<summary>Looking for older changelogs? Click here!</summary>
## Changelog for v0.1.6
- Added a timer ring component

### Minor changes
- Wrote some unit tests
- Added unit tests to CI/CD
- Added a planning document

### Bug fixes
- Fixed an issue where the timer count wouldn't reset correctly. This issue was introduced in v0.1.5

## Changelog for v0.1.5

- Added a switch where you can switch to light and dark mode, and auto-syncing with device theme to select the default one.
- Made finished timers persist in `localstorage`, and reset after midnight in your local timezone

### Minor changes

- Fixed refresh (issue #1) so the extension can be kept open all the time without any problems
- Upgraded to Svelte 5
- Change GitHub action worker to Bun
  
## Changelog for v0.1.4

- Added a huge service worker which now runs almost all progresses in the background so your timer will stay up and running when you close the pop-up window
- The timer selector now looks way cooler

### Minor changes

- Light mode is fully supported now

### Known Issues

- Certain parts of the popup only updates on refresh (BOUNTY! See issue [#1](https://github.com/ThatFrogDev/studymate/issues/1) for more information.)
- If you don't have the extension open it won't notify you when time's up.

## Changelog for v0.1.3

First release on GitHub. What came before this release: a simple timer, timer chooser, pixel art font, a sound effect and finished timer count.

### Minor changes

- Added GitHub Actions
- Added a pixel art background
- Added a play/pause icon instead of text
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Reset finished timer count" control in the popup with UI styling; clears and persists finished-session counts immediately.

* **Bug Fixes**
  * Fixed CI/CD issue that prevented automatic release builds.

* **Documentation**
  * Changelog updated and package version bumped to v0.1.7.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->